### PR TITLE
Improvement to logging.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,9 @@
 import json
 import os
 import threading
+import logging
+
+logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
 from bots.botmanager import BotManager
 from reviewboardbots.watcher import Watcher

--- a/reviewboardbots/responseagent.py
+++ b/reviewboardbots/responseagent.py
@@ -1,4 +1,5 @@
 from rbtools.api.client import RBClient
+import logging
 
 
 class ResponseAgent:
@@ -6,12 +7,13 @@ class ResponseAgent:
 
     def __init__(self, server, name, password):
         self.client = RBClient(server, username=name, password=password)
-        print("Response agent created")
+        self.name = name
 
     def respond(self, response):
 
         root = self.client.get_root()
 
+        logging.info(self.name + " is responding to review request " + str(response['request_id']))
         request = root.get_review_request(review_request_id=response['request_id'])
         review = request.get_reviews().create(body_top="")
         diff_comments = review.get_diff_comments
@@ -24,3 +26,4 @@ class ResponseAgent:
 
         #review.update(body_top=response['body_top'], ship_it=response['ship_it'], )
         review.update(**response)
+


### PR DESCRIPTION
I now log
- All the requests watcher gets when it polls
- All the requests after being filtered by bot name in watcher
- All the requests after being filtered by the db

- Requests being queued by the botmanager
- Requests being taken off then queue

- Responses being made

Hopefully this will be enough information to get a better idea of where things go wrong. For example, if a review request isn't responded to, was it because it was filtered out? Or because it never got off the queue.