### PR TITLE
making bots work in groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 *.pyc
-
-
 *.swp
 
 config.yaml
@@ -9,3 +7,177 @@ botfood_folder
 /playground.py
 *.egg-info/*
 dist/*
+
+.idea/*
+############################# generated region #######################
+# Created by https://www.gitignore.io/api/python,pycharm
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Ruby plugin and RubyMine
+/.rakeTasks
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# End of https://www.gitignore.io/api/python,pycharm

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -13,4 +13,12 @@ bots:
     password: password
     script: bots.linux_kernel_checkpatch
     max_concurrently: 1
+    
+  meangirl:
+    name: meangirl
+    password: password
+    script: bots.meangirl
+    max_concurrently: 1
+    groups:
+    - crio_installers
 

--- a/responseagent.py
+++ b/responseagent.py
@@ -4,9 +4,13 @@ import logging
 
 def review_header():
     """For usability reasons, all reivews posted by reviewboard bots should have some general information."""
-    return "You are being reviewed by a review board bot! If you have any questions or notice any issues contact " \
-           "Zach Brown at zach.brown@ni.com. Or visit this repo and leave an issue. \n https://github.com/brownzach125/reviewboardbots Also feel free to contribute!" \
-
+    from config import config
+    if 'header' in config:
+        return config['header']
+    else:
+        return "You are being reviewed by a review board bot! If you have any questions or notice any issues contact " \
+               "Zach Brown at zach.brown@ni.com. Or visit this repo and leave an issue. \n" \
+               " https://github.com/brownzach125/reviewboardbots Also feel free to contribute!"
 
 
 ###########################
@@ -94,10 +98,10 @@ class ResponseAgent:
         response.pop('diff_comments', None)
         response.pop('request_id', None)
 
-        #review.update(body_top=response['body_top'], ship_it=response['ship_it'], )
+        # review.update(body_top=response['body_top'], ship_it=response['ship_it'], )
         if not bio:
             bio = ""
-        response['body_top'] = "{0}\n\n\n{1}\n\n\n{2}".format(ResponseAgent.review_header(), bio, response['body_top'])
+        response['body_top'] = "{0}\n\n\n{1}\n\n\n{2}".format(review_header(), bio, response['body_top'])
         review.update(**response)
 
     def create_review(self, request_id, revision_id=1, message="Default bot review message", ship_it=False):
@@ -119,9 +123,7 @@ class ResponseAgent:
             'text': text
         }
 
-    @staticmethod
-    def review_header():
-        """For usability reasons, all reivews posted by reviewboard bots should have some general information."""
-        return "You are being reviewed by a review board bot! If you have any questions or notice any issues contact " \
-               "Zach Brown at zach.brown@ni.com. Or visit this repo and leave an issue. \n https://github.com/brownzach125/reviewboardbots Also feel free to contribute!" \
-
+    # @staticmethod
+    # def review_header():
+    #     """For usability reasons, all reivews posted by reviewboard bots should have some general information."""
+    #     return review_header()

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,16 @@ from setuptools import setup
 import os
 
 setup(name='reviewboardbots',
-        version='0.1',
-        description='The best ever review bot system',
-        author='Zach and Tim',
-        install_requires=[
-            'RBTools',
-            'sh',
-            'tinydb', 'pyyaml',
-        ],
-        )
+      version='0.1',
+      description='The best ever review bot system',
+      author='Zach and Tim',
+      install_requires=[
+          'RBTools',
+          'sh',
+          'tinydb', 'pyyaml',
+      ],
+      )
 
-os.mkdir('botfood_folder')
+bot_food_folder = 'botfood_folder'
+if not os.path.isdir(bot_food_folder):  # if folder does not exist,
+    os.mkdir(bot_food_folder)           # create it

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+import os
 
 setup(name='reviewboardbots',
         version='0.1',
@@ -11,3 +12,4 @@ setup(name='reviewboardbots',
         ],
         )
 
+os.mkdir('botfood_folder')

--- a/watcher.py
+++ b/watcher.py
@@ -23,13 +23,18 @@ class Watcher:
 
         self.bot_name_list = config.config['bots'].keys()
 
+        self.bot_group_list = {bot_name: config.config['bots'][bot_name]['groups']
+                               if 'groups' in config.config['bots'][bot_name]
+                               else []
+                               for bot_name in self.bot_name_list}
+
         self.bot_manager = bot_manager
         self.requests_seen = {}
         self.keep_watching = False
         # TODO make a configuration
         # Protect against non existance
         self.bot_food_path = os.path.abspath("./botfood_folder")
-        self.memory = WatcherMemory(self.client, self.bot_food_path, self.bot_name_list)
+        self.memory = WatcherMemory(self.client, self.bot_food_path, self.bot_group_list)
 
     # Get new requests from the reviewboard server
     # Same as old function, but with smarter approach


### PR DESCRIPTION
Implementing bots caring about group reviews.

Because this is implimented as 'does this bot care about this group',
bots do not need to be using accounts that are in the groups in
question, but the Watcher does - so he can be aware of the reviews and
see that a bot cares about a review to that group.


Also, make botfood_folder created on install if not exist, and added gitignore for pycharm projects to keep the repo clean